### PR TITLE
Security fix: Update tar to 7.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kmaurinjones-dev",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kmaurinjones-dev",
-			"version": "0.4.0",
+			"version": "0.4.1",
 			"dependencies": {
 				"@types/js-yaml": "^4.0.9",
 				"dotenv": "^17.2.3",
@@ -30,6 +30,7 @@
 				"svelte": "^5.39.5",
 				"svelte-check": "^4.3.2",
 				"tailwindcss": "^4.1.14",
+				"tar": "^7.5.2",
 				"typescript": "^5.9.2",
 				"vite": "^7.1.7"
 			}
@@ -2801,11 +2802,11 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "7.5.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
-			"integrity": "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==",
+			"version": "7.5.2",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
+			"integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/fs-minipass": "^4.0.0",
 				"chownr": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"svelte": "^5.39.5",
 		"svelte-check": "^4.3.2",
 		"tailwindcss": "^4.1.14",
+		"tar": "^7.5.2",
 		"typescript": "^5.9.2",
 		"vite": "^7.1.7"
 	},


### PR DESCRIPTION
## Summary
Fix Dependabot security alert by updating the `tar` package.

## Changes
- Update `tar` from 7.5.1 to 7.5.2
- Resolves CVE-2025-64118 (moderate severity)
- Fix race condition in node-tar leading to uninitialized memory exposure

## Impact
This is a transitive dependency (development only) with a moderate severity vulnerability. The vulnerability requires specific conditions to exploit (sync mode, file truncation, etc.) but should be patched regardless.

## Testing
- ✅ `npm audit` shows 0 vulnerabilities
- ✅ All existing functionality unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)